### PR TITLE
Test commit

### DIFF
--- a/src/queries/customer_segmentation.sql
+++ b/src/queries/customer_segmentation.sql
@@ -5,7 +5,7 @@ WITH customer_spending AS (
         c.customer_id,
         SUM(o.total_amount) AS total_spend,
         COUNT(o.order_id) AS total_orders,
-        MAX(o.order_date) AS last_order_date
+        MAX(TO_UTC_TIMESTAMP(o.order_date, 'Europe/Berlin')) AS last_order_date
     FROM {{ ref('customers') }} c
     JOIN {{ ref('orders') }} o ON c.customer_id = o.customer_id
     GROUP BY c.customer_id

--- a/src/queries/sales_funnel.sql
+++ b/src/queries/sales_funnel.sql
@@ -8,8 +8,8 @@ WITH funnel_data AS (
         CASE WHEN p.prospect_id IS NOT NULL THEN 1 ELSE 0 END AS is_prospect,
         CASE WHEN c.customer_id IS NOT NULL THEN 1 ELSE 0 END AS is_customer
     FROM {{ ref('leads') }} l
-    LEFT JOIN {{ ref('prospects') }} p ON l.lead_id = p.lead_id
-    LEFT JOIN {{ ref('customers') }} c ON p.prospect_id = c.prospect_id
+    LEFT JOIN {{ ref('prospects') }} AS p ON l.lead_id = p.lead_id
+    LEFT JOIN {{ ref('customers') }} AS c ON p.prospect_id = c.prospect_id
 ),
 
 -- Aggregating conversion rates
@@ -19,11 +19,11 @@ funnel_aggregates AS (
         COUNT(lead_id) AS total_leads,
         SUM(is_prospect) AS total_prospects,
         SUM(is_customer) AS total_customers,
-        ROUND(SUM(is_prospect) * 100.0 / COUNT(lead_id), 2) AS lead_to_prospect_conversion_rate,
+        ROUND(SUM(is_prospect) * 100.0 / COUNT(lead_id), 3) AS lead_to_prospect_conversion_rate,
         ROUND(SUM(is_customer) * 100.0 / SUM(is_prospect), 2) AS prospect_to_customer_conversion_rate
     FROM funnel_data
     GROUP BY lead_source
 )
 
-SELECT * FROM funnel_aggregates
-ORDER BY total_leads DESC
+SELECT *
+FROM funnel_aggregates


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the order_month calculation by converting order_date to UTC with the 'Europe/Berlin' timezone and enhance the query to default region_name to 'All Regions' when NULL.

Bug Fixes:
- Fix the calculation of order_month by converting order_date to UTC using the 'Europe/Berlin' timezone.

Enhancements:
- Ensure region_name defaults to 'All Regions' when it is NULL in the revenue growth query.

<!-- Generated by sourcery-ai[bot]: end summary -->